### PR TITLE
Update CI/CD workflows to use specific commit

### DIFF
--- a/.github/actions/pr/action.yml
+++ b/.github/actions/pr/action.yml
@@ -31,8 +31,8 @@ runs:
       if: ${{ github.event.inputs.codeql-analysis }}
       uses: github/codeql-action/init@e4262713b504983e61c7728f5452be240d9385a7 # v2.21.5 https://github.com/github/codeql-action/commit/e4262713b504983e61c7728f5452be240d9385a7
       with:
-        languages: ${{ input.codeql-language }}
-        queries: ${{ inpute.codeql-queries }} # security-extended,security-and-quality
+        languages: ${{ github.event.inputs.codeql-language }}
+        queries: ${{ github.event.inputs.codeql-queries }} # security-extended,security-and-quality
 
     - name: Autobuild
       if: ${{ github.event.inputs.codeql-analysis && github.event.inputs.codeql-build-script == "" }}

--- a/.github/workflows/_arw.yml
+++ b/.github/workflows/_arw.yml
@@ -9,6 +9,6 @@ permissions: read-all
 
 jobs:
   release:
-    uses: labsonline/cicd/.github/workflows/release.yml@latest
+    uses: labsonline/cicd/.github/workflows/release.yml@121b43dd9bbaec952cf0803972a532fde5d4adb0 # latest https://github.com/labsonline/cicd/commit/121b43dd9bbaec952cf0803972a532fde5d4adb0
     permissions:
       contents: write

--- a/.github/workflows/_cicd.yml
+++ b/.github/workflows/_cicd.yml
@@ -7,8 +7,8 @@ permissions: read-all
 
 jobs:
   bot:
-    uses: labsonline/cicd/.github/workflows/bot.yml@latest
+    uses: labsonline/cicd/.github/workflows/bot.yml@121b43dd9bbaec952cf0803972a532fde5d4adb0 # latest https://github.com/labsonline/cicd/commit/121b43dd9bbaec952cf0803972a532fde5d4adb0
   gate:
-    uses: labsonline/cicd/.github/workflows/gate.yml@latest
+    uses: labsonline/cicd/.github/workflows/gate.yml@121b43dd9bbaec952cf0803972a532fde5d4adb0 # latest https://github.com/labsonline/cicd/commit/121b43dd9bbaec952cf0803972a532fde5d4adb0
   scorecard:
-    uses: labsonline/cicd/.github/workflows/scorecard.yml@latest
+    uses: labsonline/cicd/.github/workflows/scorecard.yml@121b43dd9bbaec952cf0803972a532fde5d4adb0 # latest https://github.com/labsonline/cicd/commit/121b43dd9bbaec952cf0803972a532fde5d4adb0

--- a/.github/workflows/_cw.yaml
+++ b/.github/workflows/_cw.yaml
@@ -12,4 +12,4 @@ permissions: read-all
 
 jobs:
   cleanup:
-    uses: labsonline/cicd/.github/workflows/cleanup.yml@latest
+    uses: labsonline/cicd/.github/workflows/cleanup.yml@121b43dd9bbaec952cf0803972a532fde5d4adb0 # latest https://github.com/labsonline/cicd/commit/121b43dd9bbaec952cf0803972a532fde5d4adb0

--- a/.github/workflows/_prw.yml
+++ b/.github/workflows/_prw.yml
@@ -6,9 +6,10 @@ on:
       - edited
       - opened
       - reopened
+      - synchronize
 
 permissions: read-all
 
 jobs:
   review:
-    uses: labsonline/cicd/.github/workflows/review.yml@latest
+    uses: labsonline/cicd/.github/workflows/review.yml@121b43dd9bbaec952cf0803972a532fde5d4adb0 # latest https://github.com/labsonline/cicd/commit/121b43dd9bbaec952cf0803972a532fde5d4adb0

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -21,7 +21,7 @@ jobs:
           persist-credentials: false
 
       - name: Trivy Scan
-        uses: labsonline/cicd/.github/actions/trivy@latest
+        uses: labsonline/cicd/.github/actions/trivy@121b43dd9bbaec952cf0803972a532fde5d4adb0 # latest https://github.com/labsonline/cicd/commit/121b43dd9bbaec952cf0803972a532fde5d4adb0
         with:
           github-pat: ${{ secrets.GITHUB_TOKEN }}
           upload-scan-result: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -19,11 +19,11 @@ jobs:
         uses: kentaro-m/auto-assign-action@3e986bf9c274729de0d85191da42484917883328 # v1.2.5 https://github.com/kentaro-m/auto-assign-action/commit/3e986bf9c274729de0d85191da42484917883328
 
       - name: Lint
-        uses: labsonline/cicd/.github/actions/lint@latest
+        uses: labsonline/cicd/.github/actions/lint@121b43dd9bbaec952cf0803972a532fde5d4adb0 # latest https://github.com/labsonline/cicd/commit/121b43dd9bbaec952cf0803972a532fde5d4adb0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Review
-        uses: labsonline/cicd/.github/actions/pr@latest
+        uses: labsonline/cicd/.github/actions/pr@121b43dd9bbaec952cf0803972a532fde5d4adb0 # latest https://github.com/labsonline/cicd/commit/121b43dd9bbaec952cf0803972a532fde5d4adb0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The commit updates the CI/CD workflows to use a specific commit instead of the "latest" version. This change ensures that the workflows use a known and stable version of the code.