### PR TITLE
Refactor cleanup workflow and add scripts for cache deletion and runner configuration

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -38,19 +38,5 @@ jobs:
         env:
           BRANCH: ${{ github.event.inputs.branch }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh extension install actions/gh-actions-cache
-
-          REPO="${{ github.repository }}"
-
-          echo "Fetching list of cache key"
-          CACHE_KEYS="$(gh actions-cache list -R ${REPO} -B ${BRANCH} | cut -f 1)"
-
-          ## Setting this to not fail the workflow while deleting cache keys.
-          set +e
-          echo "Deleting caches..."
-          for KEY in ${CACHE_KEYS}
-          do
-            gh actions-cache delete "${KEY}" -R "${REPO}" -B "${BRANCH}" --confirm
-          done
-          echo "Done"
+          REPO: ${{ github.repository }}
+        run: ${{ github.action_path }}/../scripts/delete-gh-actions-cache.sh

--- a/scripts/delete-gh-actions-cache.sh
+++ b/scripts/delete-gh-actions-cache.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Copyright (c) 2023 Schubert Anselme <schubert@anselm.es>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+gh extension install actions/gh-actions-cache
+
+echo "Fetching list of cache key"
+CACHE_KEYS="$(gh actions-cache list -R ${REPO} -B ${BRANCH} | cut -f 1)"
+
+## Setting this to not fail the workflow while deleting cache keys.
+set +e
+echo "Deleting caches..."
+for KEY in ${CACHE_KEYS}
+do
+  gh actions-cache delete "${KEY}" -R "${REPO}" -B "${BRANCH}" --confirm
+done
+echo "Done"

--- a/tools/configure-gh-actions-runner.sh
+++ b/tools/configure-gh-actions-runner.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+
+# Copyright (c) 2023 Schubert Anselme <schubert@anselm.es>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+set -e
+
+RUNNER_OS="linux"
+RUNNER_VERSION="2.294.0"
+RUNNER_HASH_256="11041376754f6beaccb56101a3e79bf5fc5d6ff628460fa1ae419f9f439e24a2"
+
+##
+## Download
+##
+
+# Create a folder
+mkdir actions-runner && cd actions-runner
+
+# Download the latest runner package
+curl \
+  -o "actions-runner-${RUNNER_OS}-x64-${RUNNER_VERSION}.tar.gz" \
+  -L "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-${RUNNER_OS}-x64-${RUNNER_VERSION}.tar.gz"
+
+# Optional: Validate the hash
+echo "${RUNNER_HASH_256}  actions-runner-${RUNNER_OS}-x64-${RUNNER_VERSION}.tar.gz" | shasum -a 256 -c
+
+# Extract the installer
+tar xzf "./actions-runner-${RUNNER_OS}-x64-${RUNNER_VERSION}.tar.gz"
+
+##
+## Configure
+##
+
+# Create the runner and start the configuration experience
+./config.sh --url https://github.com/anselmes/images --token "${GH_TOKEN}"
+
+# Last step, run it!
+echo """
+# Use this YAML in your workflow file for each job
+runs-on: self-hosted
+"""
+
+# Configure to run as a service
+./svc.sh install
+./svc.sh start
+./svc.sh status


### PR DESCRIPTION
- The cleanup workflow has been refactored to utilize a script for deleting the GitHub Actions cache keys.
- A new script has been added to configure the self-hosted GitHub Actions runner.
- The cache deletion script installs the necessary extension and iterates through the cache keys to delete them.
- The runner configuration script downloads and extracts the runner package, performs validation, and starts the configuration experience.
- The runner is then configured to run as a service and its status is checked.

Closes #123.

Signed-off-by: Schubert Anselme <schubert@anselm.es>